### PR TITLE
New Script to Download Complete MLST DB

### DIFF
--- a/pubmlst_client/download_pubmlst.py
+++ b/pubmlst_client/download_pubmlst.py
@@ -30,7 +30,7 @@ def main():
         databases =  db['databases']
         for database in databases:
             if '_seqdef' in database['name']:
-                db_download_path_1 = '%s/%s' % (args.outdir,database['name'].split('_')[1])
+                db_download_path_1 = '%s/%s' % (args.outdir,database['name'][8:-7])
                 # Find MLST Schemes
                 schemes = json.loads(get(''.join([database['href'],'/schemes'])))
                 mlst_schemes = []
@@ -48,9 +48,9 @@ def main():
                     plaintext_header = {'Content-Type': 'text/plain'}
                     types_tsv = get(''.join([database['href'],'/schemes/%s/profiles_csv' % mlst_schemes[i]]), headers=plaintext_header).decode('utf-8')
                     if i > 0:
-                        output_filename = os.path.join( db_download_path , database['name'].split('_')[1] + '_%s'% (i+1) +'.txt')
+                        output_filename = os.path.join( db_download_path , database['name'][8:-7] + '_%s'% (i+1) +'.txt')
                     else:
-                        output_filename = os.path.join( db_download_path , database['name'].split('_')[1] + '.txt')
+                        output_filename = os.path.join( db_download_path , database['name'][8:-7] + '.txt')
                     with open(output_filename, 'w') as f:
                         f.write(types_tsv)
                     log_msg = {

--- a/pubmlst_client/download_pubmlst.py
+++ b/pubmlst_client/download_pubmlst.py
@@ -48,7 +48,7 @@ def main():
                     plaintext_header = {'Content-Type': 'text/plain'}
                     types_tsv = get(''.join([database['href'],'/schemes/%s/profiles_csv' % mlst_schemes[i]]), headers=plaintext_header).decode('utf-8')
                     if i > 0:
-                        output_filename = os.path.join( db_download_path , database['name'].split('_')[1] + '_%s'% i +'.txt')
+                        output_filename = os.path.join( db_download_path , database['name'].split('_')[1] + '_%s'% (i+1) +'.txt')
                     else:
                         output_filename = os.path.join( db_download_path , database['name'].split('_')[1] + '.txt')
                     with open(output_filename, 'w') as f:

--- a/pubmlst_client/download_pubmlst.py
+++ b/pubmlst_client/download_pubmlst.py
@@ -39,16 +39,16 @@ def main():
                         mlst_schemes.append(scheme['scheme'].split('/')[-1])
                 mlst_schemes.sort()
                 for i in range(len(mlst_schemes)):
-                    if i > 0:
-                        db_download_path = db_download_path_1 + "_%s" % (i+1)
+                    if int(mlst_schemes[i])> 1:
+                        db_download_path = db_download_path_1 + "_%s" % (mlst_schemes[i])
                         os.mkdir(db_download_path)
                     else:
                         db_download_path = db_download_path_1
                         os.mkdir(db_download_path)
                     plaintext_header = {'Content-Type': 'text/plain'}
                     types_tsv = get(''.join([database['href'],'/schemes/%s/profiles_csv' % mlst_schemes[i]]), headers=plaintext_header).decode('utf-8')
-                    if i > 0:
-                        output_filename = os.path.join( db_download_path , database['name'][8:-7] + '_%s'% (i+1) +'.txt')
+                    if int(mlst_schemes[i])> 1:
+                        output_filename = os.path.join( db_download_path , database['name'][8:-7] + '_%s'% (mlst_schemes[i]) +'.txt')
                     else:
                         output_filename = os.path.join( db_download_path , database['name'][8:-7] + '.txt')
                     with open(output_filename, 'w') as f:

--- a/pubmlst_client/download_pubmlst.py
+++ b/pubmlst_client/download_pubmlst.py
@@ -29,16 +29,23 @@ def main():
     for db in url_base_response:
         databases =  db['databases']
         for database in databases:
+            # rmlst is a rescrited database
+            if 'rmlst' in database['name'] or 'test' in database['name']:
+                continue
             if '_seqdef' in database['name']:
                 db_download_path_1 = '%s/%s' % (args.outdir,database['name'][8:-7])
                 # Find MLST Schemes
                 schemes = json.loads(get(''.join([database['href'],'/schemes'])))
                 mlst_schemes = []
                 for scheme in schemes['schemes']:
-                    if 'MLST' in scheme['description'] and 'cgMLST' not in scheme['description'] and 'eMLST' not in scheme['description'] :
+                    # The desription element is has some inconsistancies; this list is to navigate those.
+                    if 'MLST' == scheme['description'] or "MLST" in  scheme['description'].split(' ') and  not "Extended MLST" == scheme['description']:
+                        if  'MLST (Pla-Díaz)' == scheme['description'] and database['name'][8:-7] == 'tpallidum':
+                            continue
                         mlst_schemes.append(scheme['scheme'].split('/')[-1])
                 mlst_schemes.sort()
                 for i in range(len(mlst_schemes)):
+                    # Folders in MLST script folders are named after the organism if scheme is 1. If scheme number lager than 1 then name is organisms with sheme number appended on.
                     if int(mlst_schemes[i])> 1:
                         db_download_path = db_download_path_1 + "_%s" % (mlst_schemes[i])
                         os.mkdir(db_download_path)

--- a/pubmlst_client/download_pubmlst.py
+++ b/pubmlst_client/download_pubmlst.py
@@ -35,7 +35,7 @@ def main():
                 schemes = json.loads(get(''.join([database['href'],'/schemes'])))
                 mlst_schemes = []
                 for scheme in schemes['schemes']:
-                    if 'MLST' in scheme['description']:
+                    if 'MLST' in scheme['description'] and 'cgMLST' not in scheme['description'] and 'eMLST' not in scheme['description'] :
                         mlst_schemes.append(scheme['scheme'].split('/')[-1])
                 mlst_schemes.sort()
                 for i in range(len(mlst_schemes)):

--- a/pubmlst_client/download_pubmlst.py
+++ b/pubmlst_client/download_pubmlst.py
@@ -32,8 +32,13 @@ def main():
             if '_seqdef' in database['name']:
                 db_download_path = '%s/%s' % (args.outdir,database['name'].split('_')[1])
                 os.mkdir(db_download_path)
+                # Find MLST Scheme
+                schemes = json.loads(get(''.join([database['href'],'/schemes'])))
+                for scheme in schemes['schemes']:
+                    if scheme['description'] == 'MLST':
+                        mlst_scheme = scheme['scheme'].split('/')[-1]
                 plaintext_header = {'Content-Type': 'text/plain'}
-                types_tsv = get(''.join([database['href'],'/schemes/1/profiles_csv']), headers=plaintext_header).decode('utf-8')
+                types_tsv = get(''.join([database['href'],'/schemes/%s/profiles_csv' % mlst_scheme]), headers=plaintext_header).decode('utf-8')
                 output_filename = os.path.join( db_download_path , database['name'].split('_')[1] + '.txt')
                 with open(output_filename, 'w') as f:
                     f.write(types_tsv)
@@ -43,7 +48,7 @@ def main():
                         'filename': output_filename,
                     }
                 print(json.dumps(log_msg), file=sys.stderr)
-                db_res = json.loads(get(''.join([database['href'],'/schemes/1'])))
+                db_res = json.loads(get(''.join([database['href'],'/schemes/%s' % mlst_scheme])))
                 for locus_url in db_res['loci']:
                     locus = json.loads(get(locus_url))
                     alleles_fasta = get(locus['alleles_fasta'], headers=plaintext_header).decode('utf-8')

--- a/pubmlst_client/download_pubmlst.py
+++ b/pubmlst_client/download_pubmlst.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import os
+import re
+import urllib.request
+import sys
+import time
+import datetime
+
+from pubmlst_client.util import get
+
+
+def main():
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--outdir", "-o", dest="outdir", default='./mlstdb', help="output directory")
+    parser.add_argument("--base-url", "-b", dest="base_url", default='http://rest.pubmlst.org/db', help="Base URL for the API. Suggested values are: http://rest.pubmlst.org/db (default), https://bigsdb.pasteur.fr/api/db")
+    args = parser.parse_args()
+
+    api_url_base = args.base_url
+
+    url_base_response = json.loads(get(api_url_base))
+
+    if not os.path.exists(args.outdir):
+        os.mkdir(args.outdir)
+
+    for db in url_base_response:
+        databases =  db['databases']
+        for database in databases:
+            if '_seqdef' in database['name']:
+                db_download_path = '%s/%s' % (args.outdir,database['name'].split('_')[1])
+                os.mkdir(db_download_path)
+                plaintext_header = {'Content-Type': 'text/plain'}
+                types_tsv = get(''.join([database['href'],'/schemes/1/profiles_csv']), headers=plaintext_header).decode('utf-8')
+                output_filename = os.path.join( db_download_path , database['name'].split('_')[1] + '.txt')
+                with open(output_filename, 'w') as f:
+                    f.write(types_tsv)
+                log_msg = {
+                        'timestamp': str(datetime.datetime.now().isoformat()),
+                        'event': 'file_downloaded',
+                        'filename': output_filename,
+                    }
+                print(json.dumps(log_msg), file=sys.stderr)
+                db_res = json.loads(get(''.join([database['href'],'/schemes/1'])))
+                for locus_url in db_res['loci']:
+                    locus = json.loads(get(locus_url))
+                    alleles_fasta = get(locus['alleles_fasta'], headers=plaintext_header).decode('utf-8')
+                    output_filename = os.path.join(db_download_path, locus['id'] + '.fasta')
+                    with open(output_filename, 'w') as f:
+                        f.write(alleles_fasta)
+                    log_msg = {
+                        'timestamp': str(datetime.datetime.now().isoformat()),
+                        'event': 'file_downloaded',
+                        'filename': output_filename,
+                    }
+                    print(json.dumps(log_msg), file=sys.stderr)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
As part of the asmngs-hackathon-2024, I was pointed to the fact that the script MLST used to download a db for it uses a perl script that a large xml template and lots of placeholders. This script is used, I believe, in the nf-core module and by the developers of the StaphB docker container. https://github.com/bactopia/bactopia/blob/master/modules/nf-core/mlst/update/main.nf#L27-L40 https://github.com/tseemann/mlst/blob/master/scripts/mlst-download_pub_mlst. This new script recycles some of the code in the two other scripts in the repository and downloads the needed files from the API. Each scheme with "MLST" in its description is downloaded trying to mirror the output of the original perl script. 